### PR TITLE
avatax_origin string default

### DIFF
--- a/app/models/spree/app_configuration_decorator.rb
+++ b/app/models/spree/app_configuration_decorator.rb
@@ -10,5 +10,5 @@ Spree::AppConfiguration.class_eval do
   preference :avatax_address_validation, :boolean, default: true
   preference :avatax_tax_calculation, :boolean, default: true
   preference :avatax_document_commit, :boolean, default: true
-  preference :avatax_origin, :string, default: {}
+  preference :avatax_origin, :string, default: "{}"
 end


### PR DESCRIPTION
Since `avatax_origin` is a string it needs to default to one. This was causing errors, like #8, where a Hash was trying to be converted when a string was expected.
