### PR TITLE
Line Item Adjustments

### DIFF
--- a/app/models/spree/adjustment_decorator.rb
+++ b/app/models/spree/adjustment_decorator.rb
@@ -1,3 +1,4 @@
 Spree::Adjustment.class_eval do
   scope :avalara_tax, -> { where(source_type: 'Spree::AvalaraTransaction') }
+  scope :not_avalara_tax, -> { where.not(source_type: 'Spree::AvalaraTransaction') }
 end

--- a/app/models/spree/avalara_transaction.rb
+++ b/app/models/spree/avalara_transaction.rb
@@ -160,9 +160,9 @@ module Spree
           line[:ItemCode] = line_item.variant.sku
           line[:Qty] = line_item.quantity
           if invoice_detail == "ReturnInvoice" || invoice_detail == "ReturnOrder"
-            line[:Amount] = -line_item.total.to_f
+            line[:Amount] = -line_item.total.to_f  # Returns should return the full value
           else
-            line[:Amount] = line_item.total.to_f
+            line[:Amount] = line_item.price.to_f  # Taxes should be calculated on price alone
           end
           line[:OriginCode] = "Orig"
           line[:DestinationCode] = "Dest"

--- a/app/models/spree/avalara_transaction.rb
+++ b/app/models/spree/avalara_transaction.rb
@@ -156,7 +156,7 @@ module Spree
           line = Hash.new
           i += 1
 
-          line[:LineNo] = i
+          line[:LineNo] = line_item.id
           line[:ItemCode] = line_item.variant.sku
           line[:Qty] = line_item.quantity
           if invoice_detail == "ReturnInvoice" || invoice_detail == "ReturnOrder"
@@ -248,7 +248,7 @@ module Spree
           line = Hash.new
           i += 1
 
-          line[:LineNo] = i
+          line[:LineNo] = "#{i}-FR"
           line[:ItemCode] = "Shipping"
           line[:Qty] = 1
           if invoice_detail == "ReturnInvoice" || invoice_detail == "ReturnOrder"
@@ -276,7 +276,7 @@ module Spree
           line = Hash.new
           i += 1
 
-          line[:LineNo] = i
+          line[:LineNo] = "#{i}-PR"
           line[:ItemCode] = "Promotion"
           line[:Qty] = 1
           if invoice_detail == "ReturnInvoice" || invoice_detail == "ReturnOrder"
@@ -303,7 +303,7 @@ module Spree
 
           line = Hash.new
           i += 1
-          line[:LineNo] = i
+          line[:LineNo] = "#{i}-RA"
           line[:ItemCode] = "Return Authorization"
           line[:Qty] = 1
           if invoice_detail == "ReturnInvoice" || invoice_detail == "ReturnOrder"

--- a/app/models/spree/avalara_transaction.rb
+++ b/app/models/spree/avalara_transaction.rb
@@ -396,12 +396,12 @@ module Spree
       AVALARA_TRANSACTION_LOGGER.debug getTaxResult
 
       if getTaxResult == 'error in Tax' then
-        @myrtntax = "0.00"
+        @myrtntax = { TotalTax: "0.00" }
       else
         if getTaxResult["ResultCode"] = "Success"
           AVALARA_TRANSACTION_LOGGER.info "total tax"
           AVALARA_TRANSACTION_LOGGER.debug getTaxResult["TotalTax"].to_s
-          @myrtntax = getTaxResult["TotalTax"].to_s
+          @myrtntax = getTaxResult
         end
       end
       return @myrtntax

--- a/app/models/spree/item_adjustments_decorator.rb
+++ b/app/models/spree/item_adjustments_decorator.rb
@@ -1,0 +1,36 @@
+
+Spree::ItemAdjustments.class_eval do
+
+  def update_adjustments
+    promo_total = 0
+    run_callbacks :promo_adjustments do
+      promotion_total = adjustments.promotion.reload.map do |adjustment|
+        adjustment.update!(@item)
+      end.compact.sum
+
+      unless promotion_total == 0
+        choose_best_promotion_adjustment
+      end
+      promo_total = best_promotion_adjustment.try(:amount).to_f
+    end
+
+    included_tax_total = 0
+    additional_tax_total = 0
+    run_callbacks :tax_adjustments do
+      tax = (item.respond_to?(:all_adjustments) ? item.all_adjustments : item.adjustments).tax
+      included_tax_total = tax.is_included.reload.map(&:update!).compact.sum
+      additional_tax_total = tax.additional.reload.map(&:update!).compact.sum
+    end
+
+    avalara_tax = (item.respond_to?(:all_adjustments) ? item.all_adjustments : item.adjustments).avalara_tax
+
+    item.update_columns(
+      :promo_total => promo_total,
+      :included_tax_total => included_tax_total,
+      :additional_tax_total => additional_tax_total,
+      :adjustment_total => promo_total + additional_tax_total + avalara_tax.sum(:amount),
+      :updated_at => Time.now,
+    )
+  end
+
+end

--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -11,9 +11,4 @@ Spree::LineItem.class_eval do
     }
   end
 
-  def update_avalara_tax
-    tax = self.adjustments.avalara_tax.sum(:amount)
-    self.update(adjustment_total: tax)
-  end
-
 end

--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -15,4 +15,5 @@ Spree::LineItem.class_eval do
     tax = self.adjustments.avalara_tax.sum(:amount)
     self.update(adjustment_total: tax)
   end
+
 end

--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -10,4 +10,17 @@ Spree::LineItem.class_eval do
       'TaxCategory' => tax_category
     }
   end
+
+  def update_adjustments
+    if quantity_changed?
+      update_tax_charge # Called to ensure pre_tax_amount is updated.
+      recalculate_adjustments
+      update_avalara_tax
+    end
+  end
+
+  def update_avalara_tax
+    tax = self.adjustments.avalara_tax.sum(:amount)
+    self.update(adjustment_total: tax)
+  end
 end

--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -11,14 +11,6 @@ Spree::LineItem.class_eval do
     }
   end
 
-  def update_adjustments
-    if quantity_changed?
-      update_tax_charge # Called to ensure pre_tax_amount is updated.
-      recalculate_adjustments
-      update_avalara_tax
-    end
-  end
-
   def update_avalara_tax
     tax = self.adjustments.avalara_tax.sum(:amount)
     self.update(adjustment_total: tax)

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -56,7 +56,7 @@ Spree::Order.class_eval do
             adjustment.order = self
           end
         else
-          order_tax += tax_line["TaxCalculated"]
+          order_tax += tax_line["TaxCalculated"].to_f
         end
       end
 
@@ -106,7 +106,7 @@ Spree::Order.class_eval do
             adjustment.order = self
           end
         else
-          order_tax += tax_line["TaxCalculated"]
+          order_tax += tax_line["TaxCalculated"].to_f
         end
       end
 

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -60,7 +60,7 @@ Spree::Order.class_eval do
         end
       end
 
-      if order_tax > 0
+      if order_tax != 0
         adjustments.create do |adjustment|
           adjustment.source = avalara_transaction
           adjustment.label = 'Tax'
@@ -110,7 +110,7 @@ Spree::Order.class_eval do
         end
       end
 
-      if order_tax > 0
+      if order_tax != 0
         adjustments.create do |adjustment|
           adjustment.source = avalara_transaction
           adjustment.label = 'Tax'

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -39,7 +39,9 @@ Spree::Order.class_eval do
       logger.info 'tax amount'
       logger.debug @rtn_tax
 
-      order_tax = 0
+      shipping_tax = 0
+      promotion_tax = 0
+      return_tax = 0
 
       @rtn_tax["TaxLines"].each do |tax_line|
         if !tax_line["LineNo"].include? "-"
@@ -52,18 +54,42 @@ Spree::Order.class_eval do
             adjustment.amount = tax_line["TaxCalculated"]
             adjustment.order = self
           end
-        else
-          order_tax += tax_line["TaxCalculated"].to_f
+        elsif tax_line["LineNo"].include? "-FR"
+          shipping_tax += tax_line["TaxCalculated"].to_f
+        elsif tax_line["LineNo"].include? "-PR"
+          promotion_tax += tax_line["TaxCalculated"].to_f
+        elsif tax_line["LineNo"].include? "-RA"
+          return_tax += tax_line["TaxCalculated"].to_f
         end
       end
 
-      if order_tax != 0
+      if shipping_tax != 0
         adjustments.create do |adjustment|
           adjustment.source = avalara_transaction
-          adjustment.label = 'Tax'
+          adjustment.label = 'Shipping Tax'
           adjustment.mandatory = true
           adjustment.eligible = true
-          adjustment.amount = order_tax
+          adjustment.amount = shipping_tax
+          adjustment.order = self
+        end
+      end
+      if promotion_tax != 0
+        adjustments.create do |adjustment|
+          adjustment.source = avalara_transaction
+          adjustment.label = 'Promotion Tax'
+          adjustment.mandatory = true
+          adjustment.eligible = true
+          adjustment.amount = promotion_tax
+          adjustment.order = self
+        end
+      end
+      if return_tax != 0
+        adjustments.create do |adjustment|
+          adjustment.source = avalara_transaction
+          adjustment.label = 'Return Tax'
+          adjustment.mandatory = true
+          adjustment.eligible = true
+          adjustment.amount = return_tax
           adjustment.order = self
         end
       end
@@ -85,7 +111,9 @@ Spree::Order.class_eval do
       logger.info 'tax amount'
       logger.debug @rtn_tax
 
-      order_tax = 0
+      shipping_tax = 0
+      promotion_tax = 0
+      return_tax = 0
 
       @rtn_tax["TaxLines"].each do |tax_line|
         if !tax_line["LineNo"].include? "-"
@@ -98,18 +126,42 @@ Spree::Order.class_eval do
             adjustment.amount = tax_line["TaxCalculated"]
             adjustment.order = self
           end
-        else
-          order_tax += tax_line["TaxCalculated"].to_f
+        elsif tax_line["LineNo"].include? "-FR"
+          shipping_tax += tax_line["TaxCalculated"].to_f
+        elsif tax_line["LineNo"].include? "-PR"
+          promotion_tax += tax_line["TaxCalculated"].to_f
+        elsif tax_line["LineNo"].include? "-RA"
+          return_tax += tax_line["TaxCalculated"].to_f
         end
       end
 
-      if order_tax != 0
+      if shipping_tax != 0
         adjustments.create do |adjustment|
           adjustment.source = avalara_transaction
-          adjustment.label = 'Tax'
+          adjustment.label = 'Shipping Tax'
           adjustment.mandatory = true
           adjustment.eligible = true
-          adjustment.amount = order_tax
+          adjustment.amount = shipping_tax
+          adjustment.order = self
+        end
+      end
+      if promotion_tax != 0
+        adjustments.create do |adjustment|
+          adjustment.source = avalara_transaction
+          adjustment.label = 'Promotion Tax'
+          adjustment.mandatory = true
+          adjustment.eligible = true
+          adjustment.amount = promotion_tax
+          adjustment.order = self
+        end
+      end
+      if return_tax != 0
+        adjustments.create do |adjustment|
+          adjustment.source = avalara_transaction
+          adjustment.label = 'Return Tax'
+          adjustment.mandatory = true
+          adjustment.eligible = true
+          adjustment.amount = return_tax
           adjustment.order = self
         end
       end

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -82,7 +82,6 @@ Spree::Order.class_eval do
     logger.debug 'avalara capture finalize'
     begin
       create_avalara_transaction
-
       self.all_adjustments.avalara_tax.destroy_all
       @rtn_tax = self.avalara_transaction.commit_avatax_final(line_items, self)
 
@@ -90,6 +89,7 @@ Spree::Order.class_eval do
       logger.debug @rtn_tax
 
       order_tax = 0
+
       @rtn_tax["TaxLines"].each do |tax_line|
         if !tax_line["LineNo"].include? "-"
           line_item = Spree::LineItem.find(tax_line["LineNo"])
@@ -123,7 +123,7 @@ Spree::Order.class_eval do
       all_adjustments.avalara_tax
     rescue => e
       logger.debug e
-      logger.debug 'error in a avalara capture finalize'
+      logger.debug 'error in a avalara capture'
     end
   end
 

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -67,9 +67,6 @@ Spree::Order.class_eval do
           adjustment.order = self
         end
       end
-      line_items.each do |l|
-        l.update_avalara_tax
-      end
       self.reload.update!
       all_adjustments.avalara_tax
     rescue => e
@@ -115,9 +112,6 @@ Spree::Order.class_eval do
           adjustment.amount = order_tax
           adjustment.order = self
         end
-      end
-      line_items.each do |l|
-        l.update_avalara_tax
       end
       self.reload.update!
       all_adjustments.avalara_tax

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -33,10 +33,7 @@ Spree::Order.class_eval do
 
     begin
       create_avalara_transaction
-      self.adjustments.avalara_tax.destroy_all
-      line_items.each do |l|
-        l.adjustments.avalara_tax.destroy_all
-      end
+      self.all_adjustments.avalara_tax.destroy_all
       @rtn_tax = self.avalara_transaction.commit_avatax(line_items, self)
 
       logger.info 'tax amount'
@@ -70,8 +67,11 @@ Spree::Order.class_eval do
           adjustment.order = self
         end
       end
+      line_items.each do |l|
+        l.update_avalara_tax
+      end
       self.reload.update!
-      adjustments.avalara_tax.last
+      all_adjustments.avalara_tax
     rescue => e
       logger.debug e
       logger.debug 'error in a avalara capture'
@@ -83,17 +83,13 @@ Spree::Order.class_eval do
     begin
       create_avalara_transaction
 
-      self.adjustments.avalara_tax.destroy_all
-      line_items.each do |l|
-        l.adjustments.avalara_tax.destroy_all
-      end
+      self.all_adjustments.avalara_tax.destroy_all
       @rtn_tax = self.avalara_transaction.commit_avatax_final(line_items, self)
 
       logger.info 'tax amount'
       logger.debug @rtn_tax
 
       order_tax = 0
-
       @rtn_tax["TaxLines"].each do |tax_line|
         if !tax_line["LineNo"].include? "-"
           line_item = Spree::LineItem.find(tax_line["LineNo"])
@@ -120,8 +116,11 @@ Spree::Order.class_eval do
           adjustment.order = self
         end
       end
+      line_items.each do |l|
+        l.update_avalara_tax
+      end
       self.reload.update!
-      adjustments.avalara_tax.last
+      all_adjustments.avalara_tax
     rescue => e
       logger.debug e
       logger.debug 'error in a avalara capture finalize'
@@ -130,7 +129,7 @@ Spree::Order.class_eval do
 
   def display_avalara_tax_total
     avatax_tax = BigDecimal.new("0")
-    self.adjustments.avalara_tax.each do |tax|
+    self.all_adjustments.avalara_tax.each do |tax|
       avatax_tax += tax.amount
     end
     Spree::Money.new(avatax_tax, { currency: currency })

--- a/app/models/spree/order_updater_decorator.rb
+++ b/app/models/spree/order_updater_decorator.rb
@@ -1,0 +1,7 @@
+Spree::OrderUpdater.class_eval do
+
+  def recalculate_adjustments
+    all_adjustments.not_avalara_tax.includes(:adjustable).map(&:adjustable).uniq.each { |adjustable| Spree::ItemAdjustments.new(adjustable).update }
+  end
+
+end

--- a/spree_avatax_certified.gemspec
+++ b/spree_avatax_certified.gemspec
@@ -2,7 +2,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree_avatax_certified'
-  s.version     = '0.2.3'
+  s.version     = '0.3.0'
   s.summary     = 'Spree extension for Avalara tax calculation.'
   s.description = 'Spree extension for Avalara tax calculation.'
   s.required_ruby_version = '>= 1.9.3'

--- a/spree_avatax_certified.gemspec
+++ b/spree_avatax_certified.gemspec
@@ -2,7 +2,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree_avatax_certified'
-  s.version     = '0.3.0'
+  s.version     = '0.3.1'
   s.summary     = 'Spree extension for Avalara tax calculation.'
   s.description = 'Spree extension for Avalara tax calculation.'
   s.required_ruby_version = '>= 1.9.3'

--- a/spree_avatax_certified.gemspec
+++ b/spree_avatax_certified.gemspec
@@ -2,7 +2,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree_avatax_certified'
-  s.version     = '0.2.2'
+  s.version     = '0.2.3'
   s.summary     = 'Spree extension for Avalara tax calculation.'
   s.description = 'Spree extension for Avalara tax calculation.'
   s.required_ruby_version = '>= 1.9.3'


### PR DESCRIPTION
To better track taxes on the order it seems like we should track the tax on each `line_item` individually. This PR attaches the tax for each `line_item` to the item itself as a line item adjustment rather than a full order adjustment. Other adjustments, shipping, promotion, etc. are lumped together as an order adjustment since there are no line items for those things.