### PR TITLE
Fixed line_item total not being used in tax calculations

### DIFF
--- a/app/models/spree/avalara_transaction.rb
+++ b/app/models/spree/avalara_transaction.rb
@@ -162,7 +162,7 @@ module Spree
           if invoice_detail == "ReturnInvoice" || invoice_detail == "ReturnOrder"
             line[:Amount] = -line_item.total.to_f  # Returns should return the full value
           else
-            line[:Amount] = line_item.price.to_f  # Taxes should be calculated on price alone
+            line[:Amount] = line_item.total.to_f
           end
           line[:OriginCode] = "Orig"
           line[:DestinationCode] = "Dest"

--- a/spree_avatax_certified.gemspec
+++ b/spree_avatax_certified.gemspec
@@ -2,7 +2,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree_avatax_certified'
-  s.version     = '0.3.1'
+  s.version     = '0.3.2'
   s.summary     = 'Spree extension for Avalara tax calculation.'
   s.description = 'Spree extension for Avalara tax calculation.'
   s.required_ruby_version = '>= 1.9.3'


### PR DESCRIPTION
There was an issue where the total for the line_item was not being used and only the individual price.