### PR TITLE
adds preference switch to make Avatax log to STDOUT; updates show & edit...

### DIFF
--- a/app/controllers/spree/admin/avatax_settings_controller.rb
+++ b/app/controllers/spree/admin/avatax_settings_controller.rb
@@ -71,12 +71,13 @@ module Spree
           Spree::Config.avatax_license_key = taxpref[:avatax_license_key]
           Spree::Config.avatax_iseligible = taxpref[:avatax_iseligible]
           Spree::Config.avatax_log = taxpref[:avatax_log]
+          Spree::Config.avatax_log_to_stdout = taxpref[:avatax_log_to_stdout]
           Spree::Config.avatax_address_validation = taxpref[:avatax_address_validation]
           Spree::Config.avatax_address_validation_enabled_countries = taxpref[:avatax_address_validation_enabled_countries]
           Spree::Config.avatax_tax_calculation = taxpref[:avatax_tax_calculation]
           Spree::Config.avatax_document_commit = taxpref[:avatax_document_commit]
           Spree::Config.avatax_company_code =taxpref[:avatax_company_code]
-
+          
           respond_to do |format|
             format.html {
               redirect_to admin_avatax_settings_path

--- a/app/helpers/avatax_helper.rb
+++ b/app/helpers/avatax_helper.rb
@@ -1,9 +1,15 @@
 module AvataxHelper
   class AvataxLog
     def initialize(path_name, file_name, log_info = nil, schedule = nil)
-      schedule = "weekly" unless schedule != nil
-      @logger ||= Logger.new("#{Rails.root}/log/#{path_name}.log", schedule)
-      progname(file_name.split("/").last.chomp(".rb"))
+      if !(Spree::Config.avatax_log_to_stdout)
+        schedule = "weekly" unless schedule != nil
+        @logger ||= Logger.new("#{Rails.root}/log/#{path_name}.log", schedule)
+        progname(file_name.split("/").last.chomp(".rb"))
+      else
+        log_info = "-#{file_name} #{log_info}"
+        @logger = Logger.new(STDOUT)
+      end
+
       info(log_info) unless log_info.nil?
     end
 
@@ -23,26 +29,27 @@ module AvataxHelper
 
     def info(log_info = nil)
       if logger_enabled?
-        logger.info log_info unless log_info.nil?
+        unless log_info.nil?
+          logger.info "[AVATAX] #{log_info}"
+        end
       end
     end
 
     def info_and_debug(log_info, request_hash)
       if logger_enabled?
-        logger.info log_info
-        logger.debug request_hash
-        logger.debug JSON.generate(request_hash)
+        logger.info "[AVATAX] #{log_info}"
+        logger.debug "[AVATAX] #{request_hash}"
+        logger.debug "[AVATAX] #{JSON.generate(request_hash)}"
       end
     end
 
-
     def debug(error, text = nil)
       if logger_enabled?
-        logger.debug error
+        logger.debug "[AVATAX] #{error.inspect}"
         if text.nil?
           error
         else
-          logger.debug text
+          logger.debug "[AVATAX] text"
           text
         end
       end

--- a/app/views/spree/admin/avatax_settings/edit.html.erb
+++ b/app/views/spree/admin/avatax_settings/edit.html.erb
@@ -57,7 +57,12 @@
         <label><%= t('enable_avatax_logging') %></label><br />
         <%= check_box_tag('settings[avatax_log]','yes' , Spree::Config.avatax_log, :class => 'avatax') %>
       </p>
+	  <p>
+        <label><%= t('enable_avatax_log_to_stdout') %></label> (Use for Heroku/ephemeral deployment architecture)<br />
+        <%= check_box_tag('settings[avatax_log_to_stdout]', 'yes' , Spree::Config.avatax_log_to_stdout, :class => 'avatax') %>
+      </p>
     </fieldset>
+
 
     <fieldset>
       <legend><%= t('avatax_address_validation') %></legend>

--- a/app/views/spree/admin/avatax_settings/show.html.erb
+++ b/app/views/spree/admin/avatax_settings/show.html.erb
@@ -118,7 +118,7 @@
 
   <% else %>
    <th>Logging STDOUT enabled</th>
-   <td>Your log files are being written to STDOUT. Use this mode in a diskless (ephemeral) deploying architecture. To enable logging to disk, turn off 'Log to STDOUT'. To search your logs for all Avatax entries, look for '[AVATAX]'.</td>
+   <td>Your log files are being written to STDOUT. Use this mode in a diskless (ephemeral) deployment architecture. To enable logging to disk, turn off 'Log to STDOUT'. To search your logs for all Avatax entries, look for '[AVATAX]'.</td>
   <% end %>
 </tr>
 </table>

--- a/app/views/spree/admin/avatax_settings/show.html.erb
+++ b/app/views/spree/admin/avatax_settings/show.html.erb
@@ -88,8 +88,12 @@
   </tr>
 
 
-
   <tr>
+    <th scope="row"><%= t("avatax_log_to_stdout") %>:</th>
+    <td><%= Spree::Config.avatax_log_to_stdout %></td>
+  </tr>
+  <tr>
+    <% if ! Spree::Config.avatax_log_to_stdout %>
    <th>View Log Files</th>
    <td>
     Log files are located in the log directory of your spree website.
@@ -111,6 +115,11 @@
       </tr>
     </table>
   </td>
+
+  <% else %>
+   <th>Logging STDOUT enabled</th>
+   <td>Your log files are being written to STDOUT. Use this mode in a diskless (ephemeral) deploying architecture. To enable logging to disk, turn off 'Log to STDOUT'. To search your logs for all Avatax entries, look for '[AVATAX]'.</td>
+  <% end %>
 </tr>
 </table>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,3 +3,4 @@ en:
     avalara:
       settings: Avalara Settings
       settings_tax_use_codes: Avalara Settings Tax Use Codes
+      

--- a/lib/spree_avatax_certified/engine.rb
+++ b/lib/spree_avatax_certified/engine.rb
@@ -26,6 +26,7 @@ module SpreeAvataxCertified
         preference :avatax_tax_calculation, :boolean, default: true
         preference :avatax_document_commit, :boolean, default: true
         preference :avatax_origin, :string, default: "{}"
+        preference :avatax_log_to_stdout, :boolean, default: false
       end
     end
 


### PR DESCRIPTION
... screen for new preference; adds '[AVATAX]' to all output logging for easier searching in a logstore


FIXES https://github.com/railsdog/spree_avatax_certified/issues/32

@acreilly -- I think this should do this trick. I didn't look at master or 2-4-stable but if you'd like I can prepare separate pulls against those branches. 