### PR TITLE
Prevent `nil` values from being passed to Spree::ItemAdjustments

### DIFF
--- a/app/models/spree/order_updater_decorator.rb
+++ b/app/models/spree/order_updater_decorator.rb
@@ -1,7 +1,9 @@
 Spree::OrderUpdater.class_eval do
 
   def recalculate_adjustments
-    all_adjustments.not_avalara_tax.includes(:adjustable).map(&:adjustable).uniq.each { |adjustable| Spree::ItemAdjustments.new(adjustable).update }
+    all_adjustments.not_avalara_tax.includes(:adjustable).map(&:adjustable).uniq.compact.each do |adjustable|
+      Spree::ItemAdjustments.new(adjustable).update
+    end
   end
 
 end


### PR DESCRIPTION
  * When an adjustable (Order, Shipment, LineItem) has been deleted,
   then a `nil` value is returned.

  * Add `compact` to the mapped adjustables to prevent calling
    ItemAdjustment with `nil` values.