### PR TITLE
change default query to use boolean

### DIFF
--- a/app/models/spree/avalara_transaction.rb
+++ b/app/models/spree/avalara_transaction.rb
@@ -268,7 +268,7 @@ module Spree
     end
 
     def backup_stock_location(origin)
-      if Spree::StockLocation.find_by(default: true).nil? || Spree::StockLocation.find_by(name: 'avatax origin').nil?
+      if Spree::StockLocation.find_by(default: true).nil? && Spree::StockLocation.find_by(name: 'avatax origin').nil?
         AVALARA_TRANSACTION_LOGGER.info('avatax origin location created')
 
         return Spree::StockLocation.create(

--- a/app/models/spree/avalara_transaction.rb
+++ b/app/models/spree/avalara_transaction.rb
@@ -268,7 +268,7 @@ module Spree
     end
 
     def backup_stock_location(origin)
-      if Spree::StockLocation.find_by(name: 'default').nil? || Spree::StockLocation.find_by(name: 'avatax origin').nil?
+      if Spree::StockLocation.find_by(default: true).nil? || Spree::StockLocation.find_by(name: 'avatax origin').nil?
         AVALARA_TRANSACTION_LOGGER.info('avatax origin location created')
 
         return Spree::StockLocation.create(
@@ -282,7 +282,7 @@ module Spree
           country_id: Spree::State.find_by_name(origin["Region"]).country_id
           )
 
-      elsif Spree::StockLocation.find_by(name: 'default').city.nil? || Spree::StockLocation.first.city.nil?
+      elsif Spree::StockLocation.find_by(default: true).city.nil? || Spree::StockLocation.first.city.nil?
         AVALARA_TRANSACTION_LOGGER.info('avatax origin location updated default')
 
         return Spree::StockLocation.first.update_attributes(
@@ -297,7 +297,7 @@ module Spree
 
       else
         AVALARA_TRANSACTION_LOGGER.info('default location')
-        return Spree::StockLocation.find_by(name: 'default') || Spree::StockLocation.first
+        return Spree::StockLocation.find_by(default: true) || Spree::StockLocation.first
       end
     end
 

--- a/app/models/spree/avalara_transaction.rb
+++ b/app/models/spree/avalara_transaction.rb
@@ -268,7 +268,9 @@ module Spree
     end
 
     def backup_stock_location(origin)
-      if Spree::StockLocation.find_by(default: true).nil? && Spree::StockLocation.find_by(name: 'avatax origin').nil?
+      location = Spree::StockLocation.find_by(default: true) || Spree::StockLocation.first || Spree::StockLocation.find_by(name: 'avatax origin')
+
+      if location.nil?
         AVALARA_TRANSACTION_LOGGER.info('avatax origin location created')
 
         return Spree::StockLocation.create(
@@ -282,10 +284,10 @@ module Spree
           country_id: Spree::State.find_by_name(origin["Region"]).country_id
           )
 
-      elsif Spree::StockLocation.find_by(default: true).city.nil? || Spree::StockLocation.first.city.nil?
+      elsif location.city.nil?
         AVALARA_TRANSACTION_LOGGER.info('avatax origin location updated default')
 
-        return Spree::StockLocation.first.update_attributes(
+        return location.update_attributes(
           address1: origin["Address1"],
           address2: origin["Address2"],
           city: origin["City"],
@@ -297,7 +299,7 @@ module Spree
 
       else
         AVALARA_TRANSACTION_LOGGER.info('default location')
-        return Spree::StockLocation.find_by(default: true) || Spree::StockLocation.first
+        return location
       end
     end
 


### PR DESCRIPTION
Change the `find_by` to use `default: true` as its likely that the name of the default stock location will be updated, it is better to search for the location that is selected as the default.

For me this was causing a major issue as my default stock location was not named default, therefore, it was creating a large set of stock moves and a new location every time. In addition, the condition should be changed to `and` in that if `avatax origin` already exists we do not want to recreate it.