### PR TITLE
Tax_for_item Comparisons

### DIFF
--- a/app/models/spree/calculator/avalara_transaction_calculator.rb
+++ b/app/models/spree/calculator/avalara_transaction_calculator.rb
@@ -76,10 +76,11 @@ module Spree
       order = item.order
       item_address = order.ship_address || order.billing_address
 
-      return 0 if order.state == %w(address cart)
+      return 0 if %w(address cart).include?(order.state)
       return 0 if item_address.nil?
       return 0 if !self.calculable.zone.include?(item_address)
       return 0 if avalara_response[:TotalTax] == '0.00'
+      return 0 if avalara_response == nil
       # think about if totaltax is 0 because of an error, adding a message to the order so a user will be available.
 
       avalara_response['TaxLines'].each do |line|


### PR DESCRIPTION
Issue where it would not return 0 if the order.state was in the array. It was previously comparing array type to string type, now string to string.

I ran into an issue where avalara_response was nil on the rare case that a user's address was deleted but the order's address was not.