### PR TITLE
Only update Avatax credentials via initializer if environment variables actually exist

### DIFF
--- a/config/initializers/avatax.rb
+++ b/config/initializers/avatax.rb
@@ -4,7 +4,7 @@ AVATAX_CLIENT_VERSION = "SpreeExtV#{gem_version}"
 AVATAX_SERVICEPATH_ADDRESS = '/1.0/address/'
 AVATAX_SERVICEPATH_TAX = '/1.0/tax/'
 
-Spree::Config.avatax_company_code = ENV['AVATAX_COMPANY_CODE']
-Spree::Config.avatax_account = ENV['AVATAX_ACCOUNT']
-Spree::Config.avatax_license_key = ENV['AVATAX_LICENSE_KEY']
-Spree::Config.avatax_endpoint = ENV['AVATAX_ENDPOINT']
+Spree::Config.avatax_company_code = ENV['AVATAX_COMPANY_CODE'] if ENV['AVATAX_COMPANY_CODE']
+Spree::Config.avatax_account = ENV['AVATAX_ACCOUNT'] if ENV['AVATAX_ACCOUNT']
+Spree::Config.avatax_license_key = ENV['AVATAX_LICENSE_KEY'] if ENV['AVATAX_LICENSE_KEY']
+Spree::Config.avatax_endpoint = ENV['AVATAX_ENDPOINT'] if ENV['AVATAX_ENDPOINT']


### PR DESCRIPTION
This avoids nuking existing Avatax credentials if environment variables are missing.

Rather than doing a simple `||=` check, I opted to do an `if` check for each environment variable, as there may be some use case where we explicitly want to overwrite the Spree::Config settings from the environment, even if they are already present. 